### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,36 @@
+# Source TeX files with text in, which should contribute to word-counts.
+# (Note: abstract is handled separately)
+TEXT_SOURCES := \
+	./introduction/introduction.tex         \
+	./chapter1/chapter1.tex                 \
+	./conclusion/conclusion.tex             \
+
+# Other TeX files that should not contribute to word-counts.
+OTHER_SOURCES := \
+	./thesis.tex                            \
+	./abstract/abstract.tex                 \
+	./acknowledgements/acknowledgements.tex \
+	./appendixa/appendixa.tex               \
+	./notation/notation.tex                 \
+
+SOURCES := $(TEXT_SOURCES) $(OTHER_SOURCES)
+
 all: thesis.pdf wordcount.txt
 
-thesis.pdf: wordcount.abstract wordcount.summary wordcount.total
+thesis.pdf: wordcount.abstract wordcount.summary wordcount.total $(SOURCES)
 	latexmk --pdf
 
-wordcount.txt:
-	texcount abstract/* *.tex -sum=1,0,1 -inc -out=wordcount.txt
+wordcount.txt: $(TEXT_SOURCES)
+	texcount -sum=1,0,1 -inc $^ >$@
 
-wordcount.abstract:
-	texcount abstract/* -sum=1,0,1 -1 -out=wordcount.abstract
+wordcount.abstract: abstract/abstract.tex
+	texcount -sum=1,0,1 -1 $^ >$@
 
-wordcount.summary:
-	texcount introduction/* chapter*/* conclusion/* -sum=1,0,1 -brief -out=wordcount.summary
+wordcount.summary: $(TEXT_SOURCES)
+	texcount -sum=1,0,1 -brief $^ >$@
 
-wordcount.total:
-	texcount introduction/* chapter*/* conclusion/* -sum=1,0,1 -1 -out=wordcount.total
+wordcount.total: $(TEXT_SOURCES)
+	texcount -sum=1,0,1 -1 $^ >$@
 	
 clean:
 	latexmk -c

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: thesis.pdf clean
+all: thesis.pdf
 
 thesis.pdf:
 	texcount abstract/* *.tex -sum=1,0,1 -inc -out=wordcount.txt

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,13 @@ wordcount.txt: $(TEXT_SOURCES)
 	texcount -sum=1,0,1 -inc $^ >$@
 
 wordcount.abstract: abstract/abstract.tex
-	texcount -sum=1,0,1 -1 $^ >$@
+	texcount -sum=1,0,1 -1 -nc $^ >$@
 
 wordcount.summary: $(TEXT_SOURCES)
-	texcount -sum=1,0,1 -brief $^ >$@
+	texcount -sum=1,0,1 -brief -nc $^ >$@
 
 wordcount.total: $(TEXT_SOURCES)
-	texcount -sum=1,0,1 -1 $^ >$@
+	texcount -sum=1,0,1 -1 -nc $^ >$@
 	
 clean:
 	latexmk -c

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,19 @@
-all: thesis.pdf
+all: thesis.pdf wordcount.txt
 
-thesis.pdf:
-	texcount abstract/* *.tex -sum=1,0,1 -inc -out=wordcount.txt
-	texcount abstract/* -sum=1,0,1 -1 -out=wordcount.abstract
-	texcount introduction/* chapter*/* conclusion/* -sum=1,0,1 -brief -out=wordcount.summary
-	texcount introduction/* chapter*/* conclusion/* -sum=1,0,1 -1 -out=wordcount.total
+thesis.pdf: wordcount.abstract wordcount.summary wordcount.total
 	latexmk --pdf
+
+wordcount.txt:
+	texcount abstract/* *.tex -sum=1,0,1 -inc -out=wordcount.txt
+
+wordcount.abstract:
+	texcount abstract/* -sum=1,0,1 -1 -out=wordcount.abstract
+
+wordcount.summary:
+	texcount introduction/* chapter*/* conclusion/* -sum=1,0,1 -brief -out=wordcount.summary
+
+wordcount.total:
+	texcount introduction/* chapter*/* conclusion/* -sum=1,0,1 -1 -out=wordcount.total
 	
 clean:
 	latexmk -c

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,13 @@ wordcount.txt: $(TEXT_SOURCES)
 	texcount -sum=1,0,1 -inc $^ >$@
 
 wordcount.abstract: abstract/abstract.tex
-	texcount -sum=1,0,1 -1 -nc $^ >$@
+	texcount -sum=1,0,1 -1 -q $^ >$@
 
 wordcount.summary: $(TEXT_SOURCES)
-	texcount -sum=1,0,1 -brief -nc $^ >$@
+	texcount -sum=1,0,1 -brief -q $^ >$@
 
 wordcount.total: $(TEXT_SOURCES)
-	texcount -sum=1,0,1 -1 -nc $^ >$@
+	texcount -sum=1,0,1 -1 -q $^ >$@
 	
 clean:
 	latexmk -c

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-all: pdf clean
+all: thesis.pdf clean
 
-pdf:
+thesis.pdf:
 	texcount abstract/* *.tex -sum=1,0,1 -inc -out=wordcount.txt
 	texcount abstract/* -sum=1,0,1 -1 -out=wordcount.abstract
 	texcount introduction/* chapter*/* conclusion/* -sum=1,0,1 -brief -out=wordcount.summary

--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,19 @@ thesis.pdf:
 	
 clean:
 	latexmk -c
-	rm wordcount.abstract
-	rm wordcount.summary
-	rm wordcount.total
+	rm -f wordcount.abstract \
+	      wordcount.summary  \
+	      wordcount.total
 
 purge:
 	latexmk -C
-	rm -f wordcount.*
-	rm -f *.bbl
-	rm -f *.glsdefs
-	rm -f *.nlg
-	rm -f *.not
-	rm -f *.ntn
-	rm -f *.tdo
-	rm -f *.xml
+	rm -f wordcount.* \
+	      *.bbl 	  \
+	      *.glsdefs   \
+	      *.nlg       \
+	      *.not       \
+	      *.ntn       \
+	      *.tdo       \
+	      *.xml
 
 .PHONY: all clean purge

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,5 @@ purge:
 	rm -f *.ntn
 	rm -f *.tdo
 	rm -f *.xml
+
+.PHONY: all clean purge

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,16 @@
 # (Note: abstract is handled separately)
 TEXT_SOURCES := \
 	./introduction/introduction.tex         \
-	./chapter1/chapter1.tex                 \
 	./conclusion/conclusion.tex             \
+	$(wildcard ./chapter*/chapter*.tex)     \
 
 # Other TeX files that should not contribute to word-counts.
 OTHER_SOURCES := \
 	./thesis.tex                            \
 	./abstract/abstract.tex                 \
 	./acknowledgements/acknowledgements.tex \
-	./appendixa/appendixa.tex               \
 	./notation/notation.tex                 \
+	$(wildcard ./appendix*/appendix*.tex)   \
 
 SOURCES := $(TEXT_SOURCES) $(OTHER_SOURCES)
 


### PR DESCRIPTION
A whole bunch of tweaks to the `Makefile`. I've made most of these incrementally in my thesis repository as I wrestle with importing content from other documents (papers etc). This process has triggered all sorts of problems due to mismatches between conventions in the source documents (classes, specific packages in use, etc.) and the thesis template. In particular the changes around the word counting have made things clearer for me (and if you use `make -j`, some of the word-counting can now take place in parallel)

I've tried to make each change in independent commits and explain them in the commit message. Please let me know what you think.

 * f02d5d4 Makefile: use texcount -nc for any included file
 * 0a3a421 Makefile: explicit source file listings
 * e05d0eb Makefile: split wordcount generation out to targets
 * 6912f91 Makefile: don't clean in default target
 * 4f0d7f2 Makefile: consistently use rm -f
 * 1428b77 Makefile: rename pdf target to thesis.pdf
 * e1dcb59 Makefile: add .PHONY target
