### PR TITLE
fix standalone rules (placing artefacts in root); tidy up standalone rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,17 +25,14 @@ STANDALONE := $(wildcard */*-standalone.tex)
 standalone: $(STANDALONE:.tex=.pdf)
 
 %-standalone.pdf: %.tex
-	# latexmk passes -auxdir= to pdflatex, which doesn't understand it,
-	# so we need to redefine -pdflatex= to pass --output-directory. (We
-	# still need -auxdir for latexmk)
-	latexmk -pdf -pdflatex="pdflatex --output-directory $(@D) %O %S" -auxdir="$(@D)" $(subst pdf,tex,$@)
+	latexmk -pdf -output-directory="$(@D)" $(subst pdf,tex,$@)
 
 # fake cleanup targets
 $(addprefix clean-,$(STANDALONE)):
-	latexmk -auxdir=$(subst clean-,,$(@D)) -c $(subst clean-,,$@)
+	latexmk -output-directory="$(subst clean-,,$(@D))" -c $(subst clean-,,$@)
 
 $(addprefix purge-,$(STANDALONE)):
-	latexmk -auxdir=$(subst purge-,,$(@D)) -C $(subst purge-,,$@)
+	latexmk -output-directory="$(subst purge-,,$(@D))" -C $(subst purge-,,$@)
 
 .PHONY: $(addprefix clean-,$(STANDALONE)) $(addprefix purge-,$(STANDALONE))
 

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,8 @@ all: thesis.pdf wordcount.txt $(STANDALONE)
 ##############################################################################
 # rules for building standalone chapters.
 
-STANDALONE := $(wildcard */*-standalone.tex)
-
-standalone: $(STANDALONE:.tex=.pdf)
+STANDALONE_SOURCES := $(wildcard */*-standalone.tex)
+STANDALONE         := $(STANDALONE_SOURCES:.tex=.pdf)
 
 %-standalone.pdf: %.tex
 	latexmk -pdf -output-directory="$(@D)" $(subst pdf,tex,$@)
@@ -34,7 +33,11 @@ $(addprefix clean-,$(STANDALONE)):
 $(addprefix purge-,$(STANDALONE)):
 	latexmk -output-directory="$(subst purge-,,$(@D))" -C $(subst purge-,,$@)
 
-.PHONY: $(addprefix clean-,$(STANDALONE)) $(addprefix purge-,$(STANDALONE))
+standalone:       $(STANDALONE)
+clean-standalone: $(addprefix clean-,$(STANDALONE))
+purge-standalone: $(addprefix purge-,$(STANDALONE))
+
+.PHONY: standalone clean-standalone purge-standalone
 
 ##############################################################################
 
@@ -53,15 +56,15 @@ wordcount.summary: $(TEXT_SOURCES)
 wordcount.total: $(TEXT_SOURCES)
 	texcount -sum=1,0,1 -1 -q $^ >$@
 	
-clean: $(addprefix clean-,$(STANDALONE))
+clean: clean-standalone
 	latexmk -c
 	rm -f wordcount.abstract \
 	      wordcount.summary  \
 	      wordcount.total
 
-purge: $(addprefix purge-,$(STANDALONE))
+purge: purge-standalone
 	latexmk -C
 	rm -f wordcount.*
 	find . -regex ".*\.\(bbl\|glsdefs\|nlg\|not\|ntn\|tdo\|xml\)" -type f -delete
 
-.PHONY: all clean purge standalone
+.PHONY: all clean purge


### PR DESCRIPTION
Specify -output-directory to *latexmk*, which fixes placing the
standalone chapter PDFs in the chapter sub-directories instead of the
root.

latexmk also correctly propagates this option to pdflatex, meaning we
don't need to redefine it.

latexmk also defaults auxdir to output-directory, so we don't need to
specify that.

----

The phony clean and purge rules were incorrectly specified in terms
of the source files, not the destinations (e.g. expanding to
"clean/chapter1-standalone.tex").

Avoid defining two variables STANDALONE and standalone; use
STANDALONE_SOURCES for the former and STANDALONE for the latter.

Define phone 'clean-standalone' and 'purge-standalone' rules; group
them with the phony 'standalone' rule. Depend upon these later
instead of  doing addprefix calculations in the dependency list for
clean/purge.

declare all three .PHONY within this section of the Makefile so all
the standalone stuff is together; remove the subsequent declaration
in the bottom-most .PHONY.